### PR TITLE
Modifies the textbox for Limit to support only numbers

### DIFF
--- a/client/src/app/todos/todo-list.component.html
+++ b/client/src/app/todos/todo-list.component.html
@@ -32,7 +32,7 @@
 </mat-form-field>
 <mat-form-field class="input-field">
   <mat-label>Limit</mat-label>
-  <input matInput data-test="todoLimitFilter" placeholder="Limit the amount of todos returned"
+  <input matInput data-test="todoLimitFilter" type="number" placeholder="Limit the amount of todos returned"
     [(ngModel)]="todoLimit">
   <mat-hint>Filtered on server</mat-hint>
 </mat-form-field>


### PR DESCRIPTION
Within this commit, I added a parameter that forces the Limit input box on the Todos tab to only use numbers.